### PR TITLE
Speeding up `rotate_h_with_vqe`

### DIFF
--- a/src/boostvqe/utils.py
+++ b/src/boostvqe/utils.py
@@ -157,7 +157,7 @@ def rotate_h_with_vqe(hamiltonian, vqe):
     backend = hamiltonian.backend
     circuit = vqe.circuit
     # create circuit matrix and compute the rotation
-    matrix_circ = np.matrix(backend.to_numpy(circuit.unitary()))
+    matrix_circ = np.matrix(backend.to_numpy(circuit.fuse().unitary()))
     matrix_circ_dagger = backend.cast(matrix_circ.getH())
     matrix_circ = backend.cast(matrix_circ)
     new_hamiltonian = np.matmul(


### PR DESCRIPTION
`rotate_h_with_vqe` was slow when dealing with large number of qubits. The bottleneck seems to be related to `circuit.unitary()` which computes the unitary transformation implemented by the circuit. To speed up the execution I opted for fusing the circuit before asking for the unitary transformation.
I need to test it to check if everything is working correctly but the speed up is already visible.