### PR TITLE
Adding `eo_d` to output folder

### DIFF
--- a/compiling.py
+++ b/compiling.py
@@ -47,7 +47,7 @@ def main(args):
     path = pathlib.Path(args.path)
     dump_path = (
         path
-        / f"{args.db_rotation.name}_{args.optimization_method}_{args.epoch}e_{args.steps}s"
+        / f"{args.eo_d}_{args.db_rotation.name}_{args.optimization_method}_{args.epoch}e_{args.steps}s"
     )
     dump_path.mkdir(parents=True, exist_ok=True)
 

--- a/src/boostvqe/models/dbi/utils_gci_optimization.py
+++ b/src/boostvqe/models/dbi/utils_gci_optimization.py
@@ -12,7 +12,7 @@ def gradient_numerical(
     loss_0,
     s_0,
     mode,
-    delta: float = 1e-3,
+    delta: float = 1e-7,
 ):
     grad = np.zeros(len(params))
     for i in range(len(params)):


### PR DESCRIPTION
I've added the `eo_d` to the folder to distinguish between Ising and magnetic field evolution oracles.
I've also reduced `delta` in the `sgd` optimizer to `1e-7` after talking to @MatteoRobbiati 