### PR TITLE
Tfim simulation using 2 CNOT rather than 3 CNOT

### DIFF
--- a/src/boostvqe/models/dbi/double_bracket_evolution_oracles.py
+++ b/src/boostvqe/models/dbi/double_bracket_evolution_oracles.py
@@ -314,7 +314,7 @@ class tfim_EvolutionOracle(EvolutionOracle):
     steps: int = None
     B_a: float = None
 
-    def circuit(self, a, t_duration, steps=None, order=None):
+    def circuit(self, a, t_duration, B_a, steps=None, order=None):
         if steps is None:
             steps = self.steps
 
@@ -329,7 +329,7 @@ class tfim_EvolutionOracle(EvolutionOracle):
 
         for _ in range(steps):
             # Apply time evolution for X(a) + B_a * Z(a)
-            circuit += self._time_evolution_step(a, dt)
+            circuit += self._time_evolution_step(a, dt, B_a)
 
         # Add second CNOT(a, a+1)
         circuit.add(gates.CNOT(a, a + 1))


### PR DESCRIPTION
This pull request is to address issue 70 where we consider the special  TFIM model:

$$H^{(a)}=X_{a}X_{a+1}+B_{a}Z_{a}$$

where we can express the time evolution as 

$$e^{-itH^{(a)}}=CNOT(a,a+1)e^{-it(X_a+B_aZ_a)}CNOT(a,a+1).$$