### PR TITLE
Bug fix: EvolutionOracle initialization

### DIFF
--- a/src/boostvqe/models/dbi/double_bracket_evolution_oracles.py
+++ b/src/boostvqe/models/dbi/double_bracket_evolution_oracles.py
@@ -35,6 +35,11 @@ class EvolutionOracle:
     """Type of evolution oracle."""
 
     def __post_init__(self):
+        # if not hasattr(self, 'steps'):
+        #     self.steps = 1
+        # elif self.steps is None:
+        #     self.steps = 1
+            
         if self.steps is None:
             self.steps = 1
         """Number of steps in Trotter-Suzuki discretization."""

--- a/src/boostvqe/models/dbi/double_bracket_evolution_oracles.py
+++ b/src/boostvqe/models/dbi/double_bracket_evolution_oracles.py
@@ -35,12 +35,9 @@ class EvolutionOracle:
     """Type of evolution oracle."""
 
     def __post_init__(self):
-        # if not hasattr(self, 'steps'):
-        #     self.steps = 1
-        # elif self.steps is None:
-        #     self.steps = 1
-            
-        if self.steps is None:
+        if not hasattr(self, 'steps'):
+            self.steps = 1
+        elif self.steps is None:
             self.steps = 1
         """Number of steps in Trotter-Suzuki discretization."""
 

--- a/src/boostvqe/models/dbi/group_commutator_iteration_transpiler.py
+++ b/src/boostvqe/models/dbi/group_commutator_iteration_transpiler.py
@@ -159,14 +159,16 @@ class GroupCommutatorIterationWithEvolutionOracles:
             losses.append(self.loss(s, d, mode_dbr))
         return step_grid[np.argmin(losses)], np.min(losses), losses
 
-    def get_composed_circuit(self, step_duration=None, eo_d=None):
+    def get_composed_circuit(self, step_duration=None, eo_d=None, mode_dbr=None):
         """Get the ordered composition of all previous circuits regardless of previous mode_dbr
         settings."""
         if step_duration is None or eo_d is None:
             return self.oracle.get_composed_circuit()
         else:
+            if mode_dbr is None:
+                mode_dbr = self.mode
             return (
-                self._forward(step_duration, eo_d) + self.oracle.get_composed_circuit()
+                self._forward(step_duration, eo_d, mode_dbr) + self.oracle.get_composed_circuit()
             )
 
     @staticmethod

--- a/src/boostvqe/models/dbi/group_commutator_iteration_transpiler.py
+++ b/src/boostvqe/models/dbi/group_commutator_iteration_transpiler.py
@@ -194,10 +194,10 @@ class GroupCommutatorIterationWithEvolutionOracles:
             circuit = self.get_composed_circuit()
         return self.count_gates(circuit, gates.gates.RBS)
 
-    def get_gate_count_dict(self):
+    def get_gate_count_dict(self, composed_circuit=None):
         return dict(
-            nmb_cz=self.count_CZs() + 2 * self.count_RBS(),
-            nmb_cnot=self.count_CNOTs(),
-            nmb_cnot_relative=self.count_CZs() / self.nqubits,
-            nmb_cz_relative=self.count_CNOTs() / self.nqubits,
+            nmb_cz=self.count_CZs(composed_circuit) + 2 * self.count_RBS(composed_circuit),
+            nmb_cnot=self.count_CNOTs(composed_circuit),
+            nmb_cnot_relative=self.count_CZs(composed_circuit) / self.nqubits,
+            nmb_cz_relative=self.count_CNOTs(composed_circuit) / self.nqubits,
         )

--- a/src/boostvqe/training_utils.py
+++ b/src/boostvqe/training_utils.py
@@ -2,7 +2,7 @@ import logging
 import os
 from enum import Enum
 
-from qibo.hamiltonians.models import HamiltonianTerm, multikron
+from qibo.hamiltonians.models import HamiltonianTerm, _multikron
 
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 
@@ -61,9 +61,9 @@ def TLFIM(nqubits, h=TLFIM_h, dense=True, backend=None):
         return Hamiltonian(nqubits, ham, backend=backend)
 
     matrix = -(
-        multikron([matrices.Z, matrices.Z])
-        + h[0] * multikron([matrices.X, matrices.I])
-        + h[1] * multikron([matrices.Z, matrices.I])
+        _multikron([matrices.Z, matrices.Z])
+        + h[0] * _multikron([matrices.X, matrices.I])
+        + h[1] * _multikron([matrices.Z, matrices.I])
     )
     terms = [HamiltonianTerm(matrix, i, i + 1) for i in range(nqubits - 1)]
     terms.append(HamiltonianTerm(matrix, nqubits - 1, 0))
@@ -89,9 +89,9 @@ def J1J2(nqubits, h=J1J2_h, dense=True, backend=None):
         matrix = h[0] * (hx + hy + hz) + h[1] * (hx2 + hy2 + hz2)
         return Hamiltonian(nqubits, matrix, backend=backend)
 
-    hx = multikron([matrices.X, matrices.X])
-    hy = multikron([matrices.Y, matrices.Y])
-    hz = multikron([matrices.Z, matrices.Z])
+    hx = _multikron([matrices.X, matrices.X])
+    hy = _multikron([matrices.Y, matrices.Y])
+    hz = _multikron([matrices.Z, matrices.Z])
     matrix_1 = h[0] * (hx + hy + hz)
     matrix_2 = h[1] * (hx + hy + hz)
     terms = [HamiltonianTerm(matrix_1, i, i + 1) for i in range(nqubits - 1)]
@@ -128,9 +128,9 @@ def XYZ(nqubits, deltas=[0.5, 0.5], dense=True, backend=None):
         matrix = hx + deltas[0] * hy + deltas[1] * hz
         return Hamiltonian(nqubits, matrix, backend=backend)
 
-    hx = multikron([matrices.X, matrices.X])
-    hy = multikron([matrices.Y, matrices.Y])
-    hz = multikron([matrices.Z, matrices.Z])
+    hx = _multikron([matrices.X, matrices.X])
+    hy = _multikron([matrices.Y, matrices.Y])
+    hz = _multikron([matrices.Z, matrices.Z])
     matrix = (hx + deltas[0] * hy) + deltas[1] * hz
     terms = [HamiltonianTerm(matrix, i, i + 1) for i in range(nqubits - 1)]
     terms.append(HamiltonianTerm(matrix, nqubits - 1, 0))


### PR DESCRIPTION
This PR implements 2 simple fixes:
1. Consistent variable naming:`multikron` in `training_utils.py` → `_multikron`
2. Initializing `EvolutionOracle`: modify condition
 ```
if not hasattr(self, 'steps'):
            self.steps = 1
        elif self.steps is None:
            self.steps = 1
```
Previously, the following code snippet generates an `AttributeError: 'EvolutionOracle' object has no attribute 'steps'`
```
from boostvqe.models.dbi.double_bracket_evolution_oracles import *
from qibo import hamiltonians, set_backend
from qibo.backends import NumpyBackend
from qibo.hamiltonians import SymbolicHamiltonian
from qibo.symbols import *

# Hamiltonian initialization
set_backend("numpy")
backend = NumpyBackend()
L = 5
H_def = sum([ Z(x)*Z(x+1) +X(x)*X(x+1) +Y(x)*Y(x+1) +0.5*Z(x) for x in range(L-1)])
H_sym = SymbolicHamiltonian(H_def)

# Initialize EvolutionOracle
EvolutionOracle(H_sym, EvolutionOracleType.hamiltonian_simulation)
```
Now there should no longer be an issue.