### PR TITLE
Some fixes to run VQE trainings + derivative wrt RBS parameter

### DIFF
--- a/src/boostvqe/ansatze.py
+++ b/src/boostvqe/ansatze.py
@@ -5,14 +5,16 @@ from qibo.models import Circuit
 
 from boostvqe.training_utils import vqe_loss
 
+
 def connect_qubits(circuit, jumpsize=1, start_from=0):
     def get_circular_index(n, index):
         circular_index = index % n
         return circular_index
-    for q in range(start_from, circuit.nqubits, jumpsize+1):
+
+    for q in range(start_from, circuit.nqubits, jumpsize + 1):
         ctrl_index = q
-        targ_index = get_circular_index(circuit.nqubits, q+jumpsize)
-        circuit.add(gates.RBS(q0=ctrl_index, q1=targ_index, theta=0.))
+        targ_index = get_circular_index(circuit.nqubits, q + jumpsize)
+        circuit.add(gates.RBS(q0=ctrl_index, q1=targ_index, theta=0.0))
     return circuit
 
 
@@ -31,18 +33,16 @@ def hdw_efficient(nqubits, nlayers):
     circuit.add(gates.RY(q, theta=0) for q in range(nqubits))
 
     return circuit
-            
+
 
 def hw_preserving(nqubits, nlayers=1):
-
-    if nqubits%2 != 0:
+    if nqubits % 2 != 0:
         raise_error(
-            ValueError,
-            "To use this ansatz please be sure number of qubits is even."
-    )
+            ValueError, "To use this ansatz please be sure number of qubits is even."
+        )
     c = Circuit(nqubits)
 
-    for q in range(int(nqubits/2)):
+    for q in range(int(nqubits / 2)):
         c.add(gates.X(q))
 
     for _ in range(int(nlayers)):
@@ -54,19 +54,21 @@ def hw_preserving(nqubits, nlayers=1):
 
     return c
 
+
 def su2_preserving(nqubits, nlayers):
     """SU2 invariant circuit."""
     c = Circuit(nqubits)
     for _ in range(nlayers):
         for q in range(1, nqubits, 2):
-            c.add(gates.RXX(q0=q, q1=(q+1)%nqubits, theta=0.))
-            c.add(gates.RYY(q0=q, q1=(q+1)%nqubits, theta=0.))
-            c.add(gates.RZZ(q0=q, q1=(q+1)%nqubits, theta=0.))
+            c.add(gates.RXX(q0=q, q1=(q + 1) % nqubits, theta=0.0))
+            c.add(gates.RYY(q0=q, q1=(q + 1) % nqubits, theta=0.0))
+            c.add(gates.RZZ(q0=q, q1=(q + 1) % nqubits, theta=0.0))
         for q in range(0, nqubits, 2):
-            c.add(gates.RXX(q0=q, q1=(q+1)%nqubits, theta=0.))
-            c.add(gates.RYY(q0=q, q1=(q+1)%nqubits, theta=0.))
-            c.add(gates.RZZ(q0=q, q1=(q+1)%nqubits, theta=0.))
+            c.add(gates.RXX(q0=q, q1=(q + 1) % nqubits, theta=0.0))
+            c.add(gates.RYY(q0=q, q1=(q + 1) % nqubits, theta=0.0))
+            c.add(gates.RZZ(q0=q, q1=(q + 1) % nqubits, theta=0.0))
     return c
+
 
 def compute_gradients(parameters, circuit, hamiltonian):
     """
@@ -75,7 +77,7 @@ def compute_gradients(parameters, circuit, hamiltonian):
     over the final state get running `circuit.execute` w.r.t. rotational angles.
 
     """
-    tf_backend = construct_backend("tensorflow")
+    tf_backend = construct_backend(backend="qiboml", platform="tensorflow")
     parameters = tf_backend.tf.Variable(parameters, dtype=tf_backend.tf.float64)
 
     with tf_backend.tf.GradientTape() as tape:

--- a/src/boostvqe/boost.py
+++ b/src/boostvqe/boost.py
@@ -9,7 +9,6 @@ import numpy as np
 
 # qibo's
 from qibo import Circuit, gates, hamiltonians, set_backend
-from qibo.backends import GlobalBackend
 from qibo.models.dbi.double_bracket import (
     DoubleBracketGeneratorType,
     DoubleBracketIteration,
@@ -128,7 +127,6 @@ def dbqa_vqe(
         set_backend(backend=backend, platform=platform)
     else:
         set_backend(backend=backend)
-        platform = GlobalBackend().platform
 
     nqubits = circuit.nqubits
     # setup the results folder

--- a/src/boostvqe/plotscripts.py
+++ b/src/boostvqe/plotscripts.py
@@ -65,7 +65,7 @@ def plot_loss(
     plt.figure(figsize=(10 * width, 10 * width * 6 / 8))
     plt.title(title)
 
-    for i in range(config["nboost"]):
+    for i in range(config["nboost"] + 1):
         start = (
             0
             if str(i - 1) not in loss_vqe

--- a/src/boostvqe/training_utils.py
+++ b/src/boostvqe/training_utils.py
@@ -12,11 +12,12 @@ import tensorflow as tf
 tf.get_logger().setLevel("ERROR")
 
 from qibo import gates, hamiltonians
-from qibo.backends import GlobalBackend, NumpyBackend, TensorflowBackend, matrices
+from qibo.backends import NumpyBackend, matrices
 from qibo.config import raise_error
 from qibo.hamiltonians import AbstractHamiltonian, Hamiltonian, SymbolicHamiltonian
 from qibo.hamiltonians.models import _build_spin_model
 from qibo.symbols import Z
+from qiboml.backends import TensorflowBackend
 
 DEFAULT_DELTA = 0.5
 """Default `delta` value of XXZ Hamiltonian"""

--- a/src/boostvqe/training_utils.py
+++ b/src/boostvqe/training_utils.py
@@ -11,7 +11,7 @@ import tensorflow as tf
 
 tf.get_logger().setLevel("ERROR")
 
-from qibo import gates, hamiltonians
+from qibo import Circuit, gates, hamiltonians
 from qibo.backends import NumpyBackend, matrices
 from qibo.config import raise_error
 from qibo.hamiltonians import AbstractHamiltonian, Hamiltonian, SymbolicHamiltonian
@@ -256,7 +256,7 @@ def _exp_with_tf(circuit, hamiltonian, nshots=None):
             for p in range(nparams):
                 gradients.append(
                     upstream
-                    * parameter_shift(
+                    * quantum_derivative_via_shifts(
                         circuit=circuit,
                         hamiltonian=hamiltonian,
                         parameter_index=p,
@@ -296,6 +296,7 @@ def parameter_shift(
         )
 
     gate = circuit.associate_gates_with_parameters()[parameter_index]
+
     generator_eigenval = gate.generator_eigenvalue()
 
     s = np.pi / (4 * generator_eigenval)
@@ -320,3 +321,38 @@ def parameter_shift(
 
     circuit.set_parameters(original)
     return float(generator_eigenval * (forward - backward))
+
+
+def quantum_derivative_via_shifts(
+    hamiltonian, circuit, parameter_index, exec_backend, nshots=None
+):
+    target_gate = circuit.associate_gates_with_parameters()[parameter_index]
+    target_qubits = target_gate.qubits
+    parameter_value = target_gate.parameters[0]
+
+    if target_gate.name in ["rx", "ry", "rz"]:
+        return parameter_shift(
+            hamiltonian, circuit, parameter_index, exec_backend, nshots
+        )
+    elif target_gate.name == "rbs":
+        unrolled_rbs_circuit = Circuit(circuit.nqubits)
+        for g in circuit.queue:
+            if g != target_gate:
+                unrolled_rbs_circuit.add(g)
+            else:
+                unrolled_rbs_circuit.add(gates.H(target_qubits[0]))
+                unrolled_rbs_circuit.add(gates.CNOT(target_qubits[0], target_qubits[1]))
+                unrolled_rbs_circuit.add(gates.H(target_qubits[1]))
+                unrolled_rbs_circuit.add(gates.RY(target_qubits[0], parameter_value))
+                unrolled_rbs_circuit.add(gates.RY(target_qubits[1], -parameter_value))
+                unrolled_rbs_circuit.add(gates.H(target_qubits[1]))
+                unrolled_rbs_circuit.add(gates.CNOT(target_qubits[0], target_qubits[1]))
+                unrolled_rbs_circuit.add(gates.H(target_qubits[0]))
+
+    derivative = parameter_shift(
+        hamiltonian, unrolled_rbs_circuit, parameter_index, exec_backend, nshots
+    ) - parameter_shift(
+        hamiltonian, unrolled_rbs_circuit, parameter_index + 1, exec_backend, nshots
+    )
+
+    return derivative

--- a/train_vqes.py
+++ b/train_vqes.py
@@ -1,0 +1,113 @@
+import argparse
+import json
+import logging
+
+from boostvqe import ansatze
+from boostvqe.boost import dbqa_vqe
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run DBQA VQE optimization.")
+
+    # Required arguments
+    parser.add_argument("--output_folder", type=str, help="Output folder for results.")
+    parser.add_argument("--circuit_ansatz", type=str, help="Circuit ansatz.")
+    parser.add_argument(
+        "--nqubits",
+        type=int,
+        help="Number of particles of the problem. It will fix the number of qubits.",
+    )
+    parser.add_argument(
+        "--nlayers", type=int, help="Number of layers of the VQE ansatz."
+    )
+
+    # Optional arguments with defaults matching the function signature
+    parser.add_argument(
+        "--backend",
+        type=str,
+        default="numpy",
+        help="Quantum backend to use (default: numpy).",
+    )
+    parser.add_argument(
+        "--platform",
+        type=str,
+        default=None,
+        help="Platform for backend (e.g., 'CUDA').",
+    )
+    parser.add_argument(
+        "--optimizer",
+        type=str,
+        default="Powell",
+        help="Optimizer for VQE (default: Powell).",
+    )
+    parser.add_argument(
+        "--optimizer_options",
+        type=json.loads,
+        default={},
+        help="Optimizer options as a JSON string.",
+    )
+    parser.add_argument(
+        "--tol",
+        type=float,
+        default=1e-7,
+        help="Tolerance for optimization convergence.",
+    )
+    parser.add_argument(
+        "--decay_rate_lr", type=float, default=1.0, help="Decay rate for learning rate."
+    )
+    parser.add_argument(
+        "--nboost", type=int, default=0, help="Number of boost iterations."
+    )
+    parser.add_argument(
+        "--boost_frequency", type=int, default=10, help="Frequency of boosting calls."
+    )
+    parser.add_argument(
+        "--dbi_steps", type=int, default=1, help="Number of DBI iterations."
+    )
+    parser.add_argument(
+        "--store_h", action="store_true", help="Store Hamiltonian at each iteration."
+    )
+    parser.add_argument(
+        "--hamiltonian",
+        type=str,
+        default="XXZ",
+        help="Type of Hamiltonian (default: XXZ).",
+    )
+    parser.add_argument("--seed", type=int, default=42, help="Random seed.")
+    parser.add_argument("--nshots", type=int, default=None, help="Number of shots.")
+    parser.add_argument(
+        "--mode", type=str, default="single_commutator", help="DBI generator mode."
+    )
+
+    args = parser.parse_args()
+
+    # Set up logging
+    logging.basicConfig(level=logging.INFO)
+
+    # Load or construct the circuit from the given file path
+    circuit = getattr(ansatze, args.circuit_ansatz)(args.nqubits, args.nlayers)
+
+    # Run the DBQA VQE function
+    dbqa_vqe(
+        circuit=circuit,
+        output_folder=args.output_folder,
+        backend=args.backend,
+        platform=args.platform,
+        optimizer=args.optimizer,
+        optimizer_options=args.optimizer_options,
+        tol=args.tol,
+        decay_rate_lr=args.decay_rate_lr,
+        nboost=args.nboost,
+        boost_frequency=args.boost_frequency,
+        dbi_steps=args.dbi_steps,
+        store_h=args.store_h,
+        hamiltonian=args.hamiltonian,
+        seed=args.seed,
+        nshots=args.nshots,
+        nlayers=args.nlayers,
+        mode=args.mode,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/train_vqes.py
+++ b/train_vqes.py
@@ -2,8 +2,22 @@ import argparse
 import json
 import logging
 
+import qibo
+
 from boostvqe import ansatze
 from boostvqe.boost import dbqa_vqe
+
+
+class SpecificWarningFilter(logging.Filter):
+    def filter(self, record):
+        return (
+            "Calculating the dense form of a symbolic Hamiltonian"
+            not in record.getMessage()
+        )
+
+
+qibo_logger = qibo.config.log
+qibo_logger.addFilter(SpecificWarningFilter())
 
 
 def main():


### PR DESCRIPTION
With this PR I am:

1. fixing a couple of things related to recent qibo releases (e.g. tensorflow backend's migration);
2. writing a script to run the VQE training;
3. computing the derivative of the loss function w.r.t. the parameter of RBS gates as well (there is a decomposition + a combination of a couple of original PSR to get the result).

The VQE training script can be run with a similar shellscript:
```
#!/bin/bash

# Define variables for the parameters
OUTPUT_FOLDER="test"
CIRCUIT_ANSAZ="hw_preserving"
NQUBITS=4
NLAYERS=2
NSHOTS=10000
BACKEND="qiboml"
PLATFORM="tensorflow"
OPTIMIZER="sgd"
OPTIMIZER_OPTIONS="{ \"optimizer\": \"Adagrad\", \"learning_rate\": 0.05, \"nmessage\": 1, \"nepochs\": 50 }"

# Run the Python script with the specified arguments
python train_vqes.py    --output_folder "$OUTPUT_FOLDER" --circuit_ansatz "$CIRCUIT_ANSAZ" \
                        --nqubits "$NQUBITS" --nlayers "$NLAYERS" --backend $BACKEND \
                        --platform $PLATFORM --optimizer $OPTIMIZER \
                        --optimizer_options "$OPTIMIZER_OPTIONS"  --nshots $NSHOTS
``` 